### PR TITLE
chore(gitignore): ignore .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 .sass-cache/
 .jekyll-cache/
 .jekyll-metadata
+.ruby-version


### PR DESCRIPTION
`.ruby-version` is a local file sometimes set by `rbenv`. It should be ignored by `git` and not checked into the shared repo.

---

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[apereo cla roster]: http://licensing.apereo.org/completed-clas
[contributor license agreements]: https://www.apereo.org/licensing/agreements
