### PR TITLE
docs(index): capitalize proper nouns

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,5 +5,5 @@ layout: default
 
 # Apereo Foundation
 
-This is a prototype of a [Material Design](https://material.io/design/), [Jekyll](https://jekyllrb.com/), and [Github Pages](https://pages.github.com/) based Apereo website.
+This is a prototype of a [Material Design](https://material.io/design/), [Jekyll](https://jekyllrb.com/), and [GitHub Pages](https://pages.github.com/) based Apereo website.
 This is an unofficial Apereo community project.

--- a/index.md
+++ b/index.md
@@ -5,5 +5,5 @@ layout: default
 
 # Apereo Foundation
 
-This is a prototype of a [material design](https://material.io/design/), [jekyll](https://jekyllrb.com/), and [Github pages](https://pages.github.com/) based Apereo website.
+This is a prototype of a [Material Design](https://material.io/design/), [jekyll](https://jekyllrb.com/), and [Github pages](https://pages.github.com/) based Apereo website.
 This is an unofficial Apereo community project.

--- a/index.md
+++ b/index.md
@@ -5,5 +5,5 @@ layout: default
 
 # Apereo Foundation
 
-This is a prototype of a [Material Design](https://material.io/design/), [jekyll](https://jekyllrb.com/), and [Github pages](https://pages.github.com/) based Apereo website.
+This is a prototype of a [Material Design](https://material.io/design/), [Jekyll](https://jekyllrb.com/), and [Github pages](https://pages.github.com/) based Apereo website.
 This is an unofficial Apereo community project.

--- a/index.md
+++ b/index.md
@@ -5,5 +5,5 @@ layout: default
 
 # Apereo Foundation
 
-This is a prototype of a [Material Design](https://material.io/design/), [Jekyll](https://jekyllrb.com/), and [Github pages](https://pages.github.com/) based Apereo website.
+This is a prototype of a [Material Design](https://material.io/design/), [Jekyll](https://jekyllrb.com/), and [Github Pages](https://pages.github.com/) based Apereo website.
 This is an unofficial Apereo community project.


### PR DESCRIPTION
Nitpicky fixes to diction in `index.md` to correctly capitalize proper nouns.

---

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[apereo cla roster]: http://licensing.apereo.org/completed-clas
[contributor license agreements]: https://www.apereo.org/licensing/agreements
