### PR TITLE
feat(newsletters): add recent newsletters naively

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,7 +11,7 @@
       <a class="mdl-navigation__link" href="{{ site.baseurl }}{% link projects.md %}">Projects</a>
       <a class="mdl-navigation__link" href="{{ site.baseurl }}{% link events.md %}">Events</a>
       <a class="mdl-navigation__link" href="">Membership</a>
-      <a class="mdl-navigation__link" href="">Governance</a>
+      <a class="mdl-navigation__link" href="/governance/">Governance</a>
       <a class="mdl-navigation__link" href="">Values</a>
     </nav>
   </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,7 +11,8 @@
       <a class="mdl-navigation__link" href="{{ site.baseurl }}{% link projects.md %}">Projects</a>
       <a class="mdl-navigation__link" href="{{ site.baseurl }}{% link events.md %}">Events</a>
       <a class="mdl-navigation__link" href="">Membership</a>
-      <a class="mdl-navigation__link" href="/governance/">Governance</a>
+      <a class="mdl-navigation__link"
+        href="{{ site.baseurl }}{% link governance/README.md %}">Governance</a>
       <a class="mdl-navigation__link" href="">Values</a>
     </nav>
   </div>

--- a/governance/README.md
+++ b/governance/README.md
@@ -1,0 +1,11 @@
+---
+title: Apereo Governance
+layout: default
+permalink: governance/
+---
+
+# Governance
+
+TODO: more to say about governance.
+
++ [Newsletters](./newsletters/)

--- a/governance/newsletters/README.md
+++ b/governance/newsletters/README.md
@@ -1,0 +1,33 @@
+---
+title: Apereo Newsletters
+layout: default
+permalink: governance/newsletters/
+---
+
+# Newsletters
+
+[Subscribe][]
+
++ [May 2018][2018-05-17 newsletter]
++ [March/April 2018][2018-04-23 newsletter]
++ [February 2018][2018-02-16 newsletter]
++ [January 2018][2018-01-15 newsletter]
+
++ [December 2017][2017-12-16 newsletter]
++ [November 2017][2017-11-14 newsletter]
+
+TODO: Include newsletters that predate the adoption of MailChimp.
+
+See also [newsletter archive in MailChimp][].
+
+[Subscribe]: http://eepurl.com/c_g1TL
+
+[2018-05-17 newsletter]: http://eepurl.com/duKvxz
+[2018-04-23 newsletter]: http://eepurl.com/dsmkh5
+[2018-02-16 newsletter]: http://eepurl.com/dkB8y5
+[2018-01-15 newsletter]: http://eepurl.com/dhsLEH
+
+[2017-12-16 newsletter]: http://eepurl.com/dejfin
+[2017-11-14 newsletter]: http://eepurl.com/c_gXmP
+
+[newsletter archive in MailChimp]: https://us17.campaign-archive.com/home/?u=a275a881dc110bf42cf8aced6&id=8069ec5bd9


### PR DESCRIPTION
Adds links to recent newsletters back to November 2017 
(that is, those available via MailChimp).

In doing so, introduces a naive Governance page and links it from the existing unfulfilled Governance header link.

Hyperlinks to archived newsletters as hosted by MailChimp because the PDFs currently available from [the current apereo.org newsletters archive](https://www.apereo.org/content/newsletter-archive) seem to lack hyperlinks ([example](https://www.apereo.org/sites/default/files/Newsletters/2018/January%202018%20Apereo%20Newsletter.pdf)). The HTML as hosted by MailChimp has working hyperlinks and so provides a better experience, but relying upon this does mean that should Apereo stop using MailChimp at some future time these links will break.

There's no doubt a more clever way to do this involving iterating over a collection. Then again, Apereo doesn't publish its newsletter so very often, so maybe links in a Markdown file will prove engineered enough.

Naive Markdown `h1`s and `ul`-->`li`s as used in the new Governance and Newsletters pages don't look very good. Should probably fix that with CSS in the theme?

Using directories with `README.md` files as index pages. This is different from what `events.md` is currently doing. I'm pretty convinced the directories-with-index-pages approach is going to be cleaner for this scale and complexity of website, but regardless of where we end up on that, this changeset at least demonstrates this file layout option.

Baby steps.

---

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[apereo cla roster]: http://licensing.apereo.org/completed-clas
[contributor license agreements]: https://www.apereo.org/licensing/agreements
