### PR TITLE
feat(header): naively link root from upper left "Apereo Foundation"

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,9 @@
   <div class="mdl-layout__header-row">
     <!-- Title -->
     <span class="mdl-layout-title">
-      Apereo Foundation
+      <a href="/">
+        Apereo Foundation
+      </a>
     </span>
     <!-- Add spacer, to align navigation to the right -->
     <div class="mdl-layout-spacer"></div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
   <div class="mdl-layout__header-row">
     <!-- Title -->
     <span class="mdl-layout-title">
-      <a href="/">
+      <a href="{{ site.baseurl }}">
         Apereo Foundation
       </a>
     </span>


### PR DESCRIPTION
Naively hyperlinks "/" from "Apereo Foundation" at upper left.

Improves usability in that one can get back home from e.g. events page.

**Ugly. Need to style so doesn't look like other hyperlinks.**

---

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[apereo cla roster]: http://licensing.apereo.org/completed-clas
[contributor license agreements]: https://www.apereo.org/licensing/agreements
