### PR TITLE
feat(footer): add CC-BY-4 default to footer.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,8 @@
-<footer>
+<footer class="mdl-mini-footer">
+  <div  class="mdl-mini-footer__right-section">
     Except where otherwise noted, content on this site is licensed under the
     <a href="http://creativecommons.org/licenses/by/4.0/">
       Creative Commons Attribution 4.0 International License
     </a>.
+  </div>
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,6 @@
 <footer>
-
+    Except where otherwise noted, content on this site is licensed under the
+    <a href="http://creativecommons.org/licenses/by/4.0/">
+      Creative Commons Attribution 4.0 International License
+    </a>.
 </footer>


### PR DESCRIPTION
![screenshot showing footer displaying attractively left-aligned](https://user-images.githubusercontent.com/952283/42975522-250216a2-8b82-11e8-8e7a-27d6e81dc0ef.png)

This language is verbatim that from Creative Commons site, except without
the otherwise noted hyperlink, since its not clear there's somewhere for that to link to yet.

Differs from status quo apereo.org in that license version++ and shorter form eliding who is doing the licensing. I figure if anyone's getting this right CC is so we just don't need the longer form. Also I love the idea of direct licensing from authors to consumers and not authors to Apereo via CLA and then Apereo re-licensing to consumers. inbound==outbound. Maybe using Creative Commons' language for this in the footer can be another tiny step towards moving that culture.

---

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[apereo cla roster]: http://licensing.apereo.org/completed-clas
[contributor license agreements]: https://www.apereo.org/licensing/agreements
