### PR TITLE
fix(header): append "/" to site.baseurl in upper left link-to-root

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,7 @@
   <div class="mdl-layout__header-row">
     <!-- Title -->
     <span class="mdl-layout-title">
-      <a href="{{ site.baseurl }}">
+      <a href="{{ site.baseurl }}{% link index.md %}">
         Apereo Foundation
       </a>
     </span>


### PR DESCRIPTION
#26 attempted to add this link but it turns out an explicit trailing "/" is necessary for this link to work.