### PR TITLE
feat: display project metadata as an aside card

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,10 +3,11 @@ paginate: 10
 
 # Search engine optimizations
 url: https://apereo.foundation
+description: Apereo is a vibrant and value-driven education software foundation.
 twitter:
   username: Apereo
 facebook:
-  publisher: apereo
+  publisher: https://www.facebook.com/apereo
 social:
   name: Apereo Foundation
   links:
@@ -31,16 +32,15 @@ collections:
 defaults:
   -
     scope:
-      path: ""
-      type: projects
+      path: "" # an empty string here means all files in the project
     values:
       layout: default
   -
     scope:
       path: ""
-      type: events
+      type: projects
     values:
-      layout: default
+      layout: project
 
 # files and folders that will not be included
 exclude:
@@ -56,4 +56,5 @@ plugins:
   - jekyll-readme-index
   - jekyll-seo-tag
   - jekyll-sitemap
+  - jekyll-titles-from-headings
   - jemoji

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      {{ page.title | smartify }}
+    </title>
+    {% seo %}
+
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+    <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+  </head>
+  {{ content }}
+</html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,21 +1,12 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>
-      {{ page.title | smartify }}
-    </title>
-    {% seo %}
+---
+layout: base
+---
 
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-    <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
-    <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
-  </head>
-  <body class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
-    {% include header.html %}
-    {% include drawer.html %}
-    <main class="mdl-layout__content">
-      {{ content }}
-    </main>
-    {% include footer.html %}
-  </body>
-</html
+<body class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
+  {% include header.html %}
+  {% include drawer.html %}
+  <main class="mdl-layout__content">
+    {{ content }}
+  </main>
+  {% include footer.html %}
+</body>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -1,0 +1,64 @@
+---
+layout: default
+---
+
+<style>
+@media (min-width: 700px) {
+  .apereo-project-card {
+
+    top: 70px;
+    right: 25px;
+    position: fixed;
+  }
+  .apereo-project-content {
+    width: calc(100% - (330px + 70px));
+    min-width: 300px
+  }
+}
+
+@media (max-width: 699px) {
+  .apereo-project-card {
+    display: none;
+  }
+}
+</style>
+
+<article class="mdl-grid">
+  <aside class="apereo-project-card">
+    <div class="demo-card-wide mdl-card mdl-shadow--2dp">
+      <div class="mdl-card__title">
+        <h2 class="mdl-card__title-text">
+          {{ page.title }}
+        </h2>
+      </div>
+      <div class="mdl-card__supporting-text">
+        {{ page.description }}
+      </div>
+      <div class="mdl-card__actions mdl-card--border">
+        {% if page.project.website %}
+          <a href="{{ page.project.website }}" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
+            Website
+          </a>
+        {% endif %}
+        {% if page.project.repository %}
+          <a href="{{ page.project.repository }}" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
+            Repository
+          </a>
+        {% endif %}
+        {% if page.project.wikipedia %}
+          <a href="{{ page.project.wikipedia }}" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
+            Wikipedia
+          </a>
+        {% endif %}
+        {% if page.project.twitter %}
+          <a href=" {{page.project.twitter }}" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect">
+            Twitter
+          </a>
+        {% endif %}
+      </div>
+    </div>
+  </aside>
+  <section class="apereo-project-content">
+    {{ content }}
+  </section>
+</article>

--- a/_projects/bedework.md
+++ b/_projects/bedework.md
@@ -1,5 +1,11 @@
 ---
 title: Bedework
+description: Bedework is an open-source enterprise calendar system that supports public, personal, and group calendaring. It is designed to conform to current calendaring standards with a goal of attaining strong interoperability between other calendaring systems and clients.
+
+project:
+  repository: https://github.com/Bedework/bedework
 ---
 
 # Bedework
+
+Bedework is an open-source enterprise calendar system that supports public, personal, and group calendaring. It is designed to conform to current calendaring standards with a goal of attaining strong interoperability between other calendaring systems and clients.

--- a/_projects/elmsln.md
+++ b/_projects/elmsln.md
@@ -1,5 +1,13 @@
 ---
 title: ELMS Learning Network
+description: ELMS Learning Network (ELMSLN) is an open source educational technology platform for building and sustaining innovation in course technologies. It is a Next Generation Digital Learning Environment (NGDLE) that utilizes a Suite of Tools approach to system design and deployment. We believe it takes an ecosystem to effectively meet the needs of educators and believe in empowering faculty by treating courses as small networked ecosystems that encourage experimentation, fragmentation, growth, and then ultimately stabilization of new ideas.
+
+project:
+  website: https://www.elmsln.org
+  repository: https://github.com/elmsln/elmsln
+  twitter: https://twitter.com/elmsln
 ---
 
 # ELMS Learning Network
+
+ELMS Learning Network (ELMSLN) is an open source educational technology platform for building and sustaining innovation in course technologies. It is a Next Generation Digital Learning Environment (NGDLE) that utilizes a Suite of Tools approach to system design and deployment. We believe it takes an ecosystem to effectively meet the needs of educators and believe in empowering faculty by treating courses as small networked ecosystems that encourage experimentation, fragmentation, growth, and then ultimately stabilization of new ideas.

--- a/_projects/karuta.md
+++ b/_projects/karuta.md
@@ -1,5 +1,12 @@
 ---
 title: Karuta
+description: Karuta is a flexible tool for the incremental prototyping and the diffusion on the web of digital portfolios or eportfolios for various purposes; showcase portfolio, learning portfolio, assessment portfolio.
+
+project:
+  website: http://karutaproject.org
+  repository: https://github.com/karutaproject
 ---
 
 # Karuta
+
+Karuta is a flexible tool for the incremental prototyping and the diffusion on the web of digital portfolios or eportfolios for various purposes; showcase portfolio, learning portfolio, assessment portfolio.

--- a/_projects/open-academic-environment.md
+++ b/_projects/open-academic-environment.md
@@ -1,5 +1,13 @@
 ---
 title: Open Academic Environment
+description: The Open Academic Environment is a powerful new way for researchers, students and faculty to create knowledge, share, collaborate and connect with the world. It is a multi-tenant and highly scalable platform that is able to support multiple institutions at the same time.
+
+project:
+  website: http://oaeproject.org
+  repository: https://github.com/oaeproject
+  twitter: https://twitter.com/OAEProject
 ---
 
 # Open Academic Environment
+
+The Open Academic Environment is a powerful new way for researchers, students and faculty to create knowledge, share, collaborate and connect with the world. It is a multi-tenant and highly scalable platform that is able to support multiple institutions at the same time.

--- a/_projects/open-equella.md
+++ b/_projects/open-equella.md
@@ -1,5 +1,15 @@
 ---
 title: Open Equella
+description: Open EQUELLA is a digital repository that provides a single platform to house teaching/learning, research, media, and library content.
+
+project:
+  website: https://equella.github.io
+  repository: https://github.com/equella/Equella
+  twitter: https://twitter.com/equella
 ---
 
 # Open Equella
+
+Open EQUELLA is a digital repository that provides a single platform to house teaching/learning, research, media, and library content.
+
+Open EQUELLA has been deployed for copyright resource collections; research materials; managing and exposing materials through websites and portals; content authoring; workflow; institutional policy; and organizational resources. Open EQUELLA is currently in use in a wide range of schools, universities, colleges, TAFEs, departments of education, government agencies, and corporations worldwide.

--- a/_projects/opencast.md
+++ b/_projects/opencast.md
@@ -1,5 +1,14 @@
 ---
 title: Opencast
+description: The Opencast community is a collaboration of individuals, higher education institutions and organizations working together to explore, develop, define and document best practices and technologies for management of audiovisual content in academia.
+
+project:
+  website: https://opencast.org
+  repository: https://github.com/opencast/opencast
+  wikipedia: https://en.wikipedia.org/wiki/Opencast_(software)
+  twitter: https://twitter.com/openmatter
 ---
 
 # Opencast
+
+The Opencast community is a collaboration of individuals, higher education institutions and organizations working together to explore, develop, define and document best practices and technologies for management of audiovisual content in academia.

--- a/_projects/sakai.md
+++ b/_projects/sakai.md
@@ -1,5 +1,14 @@
 ---
 title: Sakai
+description: The Sakai Project is a robust LMS system supporting over 4 million educational users to enhance collaborative teaching, learning and research.
+
+project:
+  website: https://www.sakaiproject.org
+  repository: https://github.com/sakaiproject
+  wikipedia: https://en.wikipedia.org/wiki/Sakai_(software)
+  twitter: https://twitter.com/sakaiproject
 ---
 
 # Sakai
+
+The Sakai Project is a robust LMS system supporting over 4 million educational users to enhance collaborative teaching, learning and research.

--- a/_projects/unitime.md
+++ b/_projects/unitime.md
@@ -1,5 +1,13 @@
 ---
 title: UniTime
+description: UniTime is a comprehensive educational scheduling system that supports developing course and exam timetables, managing changes to these timetables, sharing rooms with other events, and scheduling students to individual classes. It is a distributed system that allows multiple university and departmental schedule managers to coordinate efforts to build and modify a schedule that meets their diverse organizational needs while allowing for minimization of student course conflicts.
+
+project:
+  website: http://www.unitime.org
+  repository: https://github.com/UniTime
+  twitter: https://twitter.com/UniTimeOrg
 ---
 
 # UniTime
+
+UniTime is a comprehensive educational scheduling system that supports developing course and exam timetables, managing changes to these timetables, sharing rooms with other events, and scheduling students to individual classes. It is a distributed system that allows multiple university and departmental schedule managers to coordinate efforts to build and modify a schedule that meets their diverse organizational needs while allowing for minimization of student course conflicts.

--- a/_projects/uportal-home.md
+++ b/_projects/uportal-home.md
@@ -1,5 +1,14 @@
 ---
 title: uPortal-home
+description: uPortal-home is an alternative user interface for some of the most frequent user interactions in uPortal.
+
+project:
+  website: https://uportal.org
+  repository: https://github.com/uPortal-Project/uportal-home
+  wikipedia: https://en.wikipedia.org/wiki/UPortal
+  twitter: https://twitter.com/uportal
 ---
 
 # uPortal-home
+
+uPortal-home is an alternative user interface for some of the most frequent user interactions in uPortal

--- a/_projects/uportal.md
+++ b/_projects/uportal.md
@@ -1,5 +1,14 @@
 ---
 title: uPortal
+description: uPortal is an open source enterprise portal framework built by and for higher education institutions, K-12 schools, and research communities. uPortal is built on open standards-based technologies such as Java and XML, and enables easy, standards-based integration with authentication and security infrastructures, single sign-on secure access, campus applications, web-based content, and end user customization.
+
+project:
+  website: http://uportal.org
+  repository: https://github.com/jasig/uPortal
+  wikipedia: https://en.wikipedia.org/wiki/UPortal
+  twitter: https://twitter.com/uportal
 ---
 
 # uPortal
+
+uPortal is an open source enterprise portal framework built by and for higher education institutions, K-12 schools, and research communities. uPortal is built on open standards-based technologies such as Java and XML, and enables easy, standards-based integration with authentication and security infrastructures, single sign-on secure access, campus applications, web-based content, and end user customization.

--- a/_projects/xerte.md
+++ b/_projects/xerte.md
@@ -1,5 +1,13 @@
 ---
 title: Xerte
+description: The Xerte Project provides a full suite of open source tools for elearning developers and content authors producing interactive learning materials.
+
+project:
+  website: https://www.xerte.org.uk
+  wikipedia: https://en.wikipedia.org/wiki/Xerte
+  twitter: https://twitter.com/xerte_project
 ---
 
 # Xerte
+
+The Xerte Project provides a full suite of open source tools for elearning developers and content authors producing interactive learning materials.

--- a/events.md
+++ b/events.md
@@ -1,6 +1,5 @@
 ---
 title: Apereo Events
-layout: default
 permalink: events/
 ---
 

--- a/index.md
+++ b/index.md
@@ -1,6 +1,5 @@
 ---
 title: Apereo Foundation
-layout: default
 ---
 
 # Apereo Foundation

--- a/projects.md
+++ b/projects.md
@@ -1,8 +1,10 @@
 ---
 title: Apereo Projects
-layout: default
 permalink: projects/
+description: Apereo is made up of a series of overlapping and interlocking software, regional and thematic communities.
 ---
+
+Apereo is made up of a series of overlapping and interlocking software, regional and thematic communities.
 
 ## Projects
 
@@ -15,7 +17,7 @@ permalink: projects/
       <a href="{{ project.url }}">
         <i class="material-icons mdl-list__item-avatar">public</i>
         <span>{{ project.title }}</span>
-        <span class="mdl-list__item-sub-title">{{ project.description }}</span>
+        <span class="mdl-list__item-text-body">{{ project.description }}</span>
       </a>
     </li>
 
@@ -36,7 +38,7 @@ permalink: projects/
       <a href="{{ project.url }}">
         <i class="material-icons mdl-list__item-avatar">public</i>
         <span>{{ project.title }}</span>
-        <span class="mdl-list__item-sub-title">{{ project.description }}</span>
+        <span class="mdl-list__item-text-body">{{ project.description }}</span>
       </a>
     </li>
 


### PR DESCRIPTION
uses frontmatter `project` key to store links to project pages, uses title and description for body of card.

![selection_011](https://user-images.githubusercontent.com/3107513/42972473-7107ad3c-8b64-11e8-9458-158a808e7174.png)

---

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[apereo cla roster]: http://licensing.apereo.org/completed-clas
[contributor license agreements]: https://www.apereo.org/licensing/agreements
