### PR TITLE
refactor: style header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,8 @@
   <div class="mdl-layout__header-row">
     <!-- Title -->
     <span class="mdl-layout-title">
-      <a href="{{ site.baseurl }}{% link index.md %}">
+      <a class="apereo-header-title-link"
+        href="{{ site.baseurl }}{% link index.md %}">
         Apereo Foundation
       </a>
     </span>
@@ -10,13 +11,25 @@
     <div class="mdl-layout-spacer"></div>
     <!-- Navigation. We hide it in small screens. -->
     <nav class="mdl-navigation mdl-layout--large-screen-only">
-      <a class="mdl-navigation__link" href="{{ site.baseurl }}{% link projects.md %}">Projects</a>
-      <a class="mdl-navigation__link" href="{{ site.baseurl }}{% link events.md %}">Events</a>
       <a class="mdl-navigation__link"
-        href="{{ site.baseurl }}{% link membership/README.md %}">Memberships</a>
+        href="{{ site.baseurl }}{% link projects.md %}">
+        Projects
+      </a>
       <a class="mdl-navigation__link"
-        href="{{ site.baseurl }}{% link governance/README.md %}">Governance</a>
-      <a class="mdl-navigation__link" href="">Values</a>
+        href="{{ site.baseurl }}{% link events.md %}">
+        Events
+      </a>
+      <a class="mdl-navigation__link"
+        href="{{ site.baseurl }}{% link membership/README.md %}">
+        Memberships
+      </a>
+      <a class="mdl-navigation__link"
+        href="{{ site.baseurl }}{% link governance/README.md %}">
+        Governance
+      </a>
+      <a class="mdl-navigation__link" href="">
+        Values
+      </a>
     </nav>
   </div>
 </header>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -8,6 +8,7 @@
 
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+    <link rel="stylesheet" href="{{ "/assets/css/style.css" | absolute_url }}">
     <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
   </head>
   {{ content }}

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ page.lang | site.lang | default: "en" }}">
   <head>
     <title>
       {{ page.title | smartify }}

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -2,27 +2,6 @@
 layout: default
 ---
 
-<style>
-@media (min-width: 700px) {
-  .apereo-project-card {
-
-    top: 70px;
-    right: 25px;
-    position: fixed;
-  }
-  .apereo-project-content {
-    width: calc(100% - (330px + 70px));
-    min-width: 300px
-  }
-}
-
-@media (max-width: 699px) {
-  .apereo-project-card {
-    display: none;
-  }
-}
-</style>
-
 <article class="mdl-grid">
   <aside class="apereo-project-card">
     <div class="demo-card-wide mdl-card mdl-shadow--2dp">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,23 @@
+.apereo-header-title-link {
+  color: rgb(255, 255, 255);
+  text-decoration: none;
+}
+
+@media (min-width: 700px) {
+  .apereo-project-card {
+
+    top: 70px;
+    right: 25px;
+    position: fixed;
+  }
+  .apereo-project-content {
+    width: calc(100% - (330px + 70px));
+    min-width: 300px
+  }
+}
+
+@media (max-width: 699px) {
+  .apereo-project-card {
+    display: none;
+  }
+}


### PR DESCRIPTION
Header title is back to more consistent styling.

![selection_012](https://user-images.githubusercontent.com/3107513/42980603-f076e114-8b8c-11e8-876e-525829643f8f.png)

Styles have been moved to their own file.
All custom styles have an `apereo` prefix.
Sets the page language.

resolves #32

---

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[apereo cla roster]: http://licensing.apereo.org/completed-clas
[contributor license agreements]: https://www.apereo.org/licensing/agreements
