### PR TITLE
feat(colophon): link Apereo lightning talk wrt GitHub Pages

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,3 +6,12 @@ title: Apereo Foundation
 
 This is a prototype of a [Material Design](https://material.io/design/), [Jekyll](https://jekyllrb.com/), and [GitHub Pages](https://pages.github.com/) based Apereo website.
 This is an unofficial Apereo community project.
+
+## Context
+
++ Apereo lightning talk on GitHub pages: ([5 minute video][2017-01-19 video]),
+  [slides and supporting resources][apetro/github-pages-lightning-talk]
+
+
+[2017-01-19 video]: https://www.youtube.com/watch?v=eEKZZTt6QAs&feature=youtu.be&t=7m59s
+[apetro/github-pages-lightning-talk]: https://github.com/apetro/github-pages-lightning-talk


### PR DESCRIPTION
The idea here is to add some supporting links and resources to help people understand this project and its context, the promise in using a static site generator and site source in public source control in general and GitHub Pages in specific for implementing the Apereo website.

Long-term the index page probably isn't the place for this. Maybe invent a colophon for meta about the website and its making.

But in the near term, maybe the index page is the right place for this. This isn't the website yet, so the casual viewer's primary purpose may not be learning about Apereo so much as it is the meta angle of learning about this approach to building a website about Apereo.

Anyway, linking my own lightning talk is both particularly self-indulgent (and so would benefit from scrutiny, second opinions, and evolutions by peers), and also is maybe pretty important, in that this project isn't coming out of the blue sky, it's the next step in a confluence of long-running threads of exploration in Apereo.

---

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[apereo cla roster]: http://licensing.apereo.org/completed-clas
[contributor license agreements]: https://www.apereo.org/licensing/agreements
