### PR TITLE
feat(newsletters): link Google Groups hosted newsletters back thru 2016

### DIFF
--- a/governance/newsletters/README.md
+++ b/governance/newsletters/README.md
@@ -15,10 +15,22 @@ permalink: governance/newsletters/
 
 + [December 2017][2017-12-16 newsletter]
 + [November 2017][2017-11-14 newsletter]
++ [April 2017][2017-04-11 newsletter]
++ [January 2017][2017-01-29 newsletter]
 
-TODO: Include newsletters that predate the adoption of MailChimp.
++ [November 2016][2016-11-27 newsletter]
++ [October 2016][2016-10-24 newsletter]
++ [September 2016][2016-09-19 newsletter]
++ [May 2016][2016-05-12 newsletter]
++ [March 2016][2016-03-16 newsletter]
++ [January 2016][2016-01-24 newsletter]
 
-See also [newsletter archive in MailChimp][].
+TODO: Include newsletters from prior to 2016.
+
+See also
+
++ [newsletter archive in MailChimp][] (recent newsletters)
++ [Apereo announcements Google Group][] (older newsletters)
 
 [Subscribe]: http://eepurl.com/c_g1TL
 
@@ -29,5 +41,16 @@ See also [newsletter archive in MailChimp][].
 
 [2017-12-16 newsletter]: http://eepurl.com/dejfin
 [2017-11-14 newsletter]: http://eepurl.com/c_gXmP
+[2017-04-11 newsletter]: https://groups.google.com/a/apereo.org/d/msg/announcements/NKaKb9V1b3Q/JGgB7_K6BwAJ
+[2017-01-29 newsletter]: https://groups.google.com/a/apereo.org/d/msg/announcements/gEubp0iejn4/IMyt-AfjBQAJ
+
+[2016-11-27 newsletter]: https://groups.google.com/a/apereo.org/d/msg/announcements/lN-12ZSwH0g/kJUY23FJCAAJ
+[2016-10-24 newsletter]: https://groups.google.com/a/apereo.org/d/msg/announcements/KKLfPGCcnfw/OiKYkVnFAQAJ
+[2016-09-19 newsletter]: https://groups.google.com/a/apereo.org/d/msg/announcements/y1c-AErU0co/_7Kz8aBRBwAJ
+[2016-05-12 newsletter]: https://groups.google.com/a/apereo.org/d/msg/announcements/sI8l-FxSw0k/1Wc0-OFoBwAJ
+[2016-03-16 newsletter]: https://groups.google.com/a/apereo.org/d/msg/announcements/mra0fJ7Wba8/zBuM7kGPCgAJ
+[2016-01-24 newsletter]: https://groups.google.com/a/apereo.org/d/msg/announcements/dzZ9fw3C_Dk/b3yfEHpvBAAJ
 
 [newsletter archive in MailChimp]: https://us17.campaign-archive.com/home/?u=a275a881dc110bf42cf8aced6&id=8069ec5bd9
+
+[Apereo announcements Google Group]: https://groups.google.com/a/apereo.org/forum/#!forum/announcements


### PR DESCRIPTION
Enhances newsletters page to link more newsletters, now back through 2016.

There are more older newsletters not yet linked.

---

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[apereo cla roster]: http://licensing.apereo.org/completed-clas
[contributor license agreements]: https://www.apereo.org/licensing/agreements
