### PR TITLE
feat(audit): add page re audit committee

### DIFF
--- a/governance/README.md
+++ b/governance/README.md
@@ -8,4 +8,6 @@ permalink: governance/
 
 TODO: more to say about governance.
 
++ [Apereo Board of Directors](./board/)
+
 + [Newsletters](./newsletters/)

--- a/governance/board/README.md
+++ b/governance/board/README.md
@@ -1,6 +1,7 @@
 ---
 title: Apereo Board
 layout: default
+permalink: governance/board/
 ---
 
 # Apereo Board of Directors

--- a/governance/board/README.md
+++ b/governance/board/README.md
@@ -1,0 +1,25 @@
+---
+title: Apereo Board
+layout: default
+---
+
+# Apereo Board of Directors
+
+Apereo has a Board of Directors.
+
+TODO: Much more to say about the Board.
+
+## Standing Committees
+
+The Apereo bylaws require two standing committees
+
+> The Board shall annually determine the membership of two (2) Standing
+> Committees: ... A Remuneration Committee ... \[and] An Audit Committee ...
+> (VIII.1.B)
+
+TODO: Hyperlink the bylaws once they're in this site.
+
++ [Audit committee](./audit/)
++ Remuneration committee
+
+TODO: Create page for remuneration committee

--- a/governance/board/audit/README.md
+++ b/governance/board/audit/README.md
@@ -1,0 +1,49 @@
+---
+title: Audit Committee
+layout: default
+---
+
+# Audit committee
+
+The Apereo bylaws require a standing audit committee.
+
+> The Board shall annually determine the membership of two (2) Standing
+> Committees: ... A Remuneration Committee ... \[and] An Audit Committee, the
+> role of which is to oversee or conduct an annual audit of Foundation finances.
+> (VIII.1.B)
+
+## Audit committee membership
+
+TODO: Acknowledge who serves on this committee. Since when? Terms expire when?
+In what roles? Does this committee have a chair, etc.?
+
+## Reports and deliverables
+
+TODO: Add or link reports and deliverables. Annual audits produced by or
+overseen by the committee. Other reports and public documents.
+
+### See also
+
++ Apereo annual reports include a brief unaudited financial summary
++ Apereo 990s are available via public sites such as
+  [Foundation Center][Apereo 990s on Foundation Center]
+
+TODO: Hyperlink annual reports when they are available on this site.
+TODO: Hyperlink 990s if and when they're available on this site (some of
+Apereo's older 990s assert that Apereo will make a copy of the 990 available
+on its website, so Apereo may be obligated to do this. More recent 990s don't
+check this box, but it still seems a best practice in the interest of
+transparency and openness).
+
+## Meetings and minutes
+
+TODO: Are dates of past and future meetings available?
+TODO: Are these open meetings? Could anyone join? How?
+TODO: Are minutes of past meetings available?
+
+## Previous committee members
+
+TODO: Who should be thanked for past service on this committee? With what dates
+of service?
+
+[Apereo 990s on Foundation Center]: http://990finder.foundationcenter.org/990results.aspx?990_type=&fn=Apereo&st=&zp=&ei=&fy=&action=Search

--- a/governance/board/audit/README.md
+++ b/governance/board/audit/README.md
@@ -1,6 +1,7 @@
 ---
 title: Audit Committee
 layout: default
+permalink: governance/board/audit/
 ---
 
 # Audit committee


### PR DESCRIPTION
Incidentally adds placeholder board page to get there.

Lots of TODOs dropping in here about things that could be transparent about this committee but are not yet transparent. Which is kind of my point. A lower friction website has tremendous potential to help Apereo be more open and transparent, and to do so sustainably.

---

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[apereo cla roster]: http://licensing.apereo.org/completed-clas
[contributor license agreements]: https://www.apereo.org/licensing/agreements
