### PR TITLE
fix: use default filter to apply site.lang as fallback language

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ page.lang | site.lang | default: "en" }}">
+<html lang="{{ page.lang | default: site.lang | default: "en" }}">
   <head>
     <title>
       {{ page.title | smartify }}


### PR DESCRIPTION
resolves #41 

---

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[apereo cla roster]: http://licensing.apereo.org/completed-clas
[contributor license agreements]: https://www.apereo.org/licensing/agreements
